### PR TITLE
#77 - fix Kubernetes context switch when the recommended home directo…

### DIFF
--- a/cmd/cluster.go
+++ b/cmd/cluster.go
@@ -206,6 +206,10 @@ func (cc *ClusterCommands) mergeKubeConfigs(clusterContext []byte) error {
 		return err
 	}
 
+	if err := os.MkdirAll(util.GetHomePath(clientcmd.RecommendedHomeDir), 0755); err != nil {
+		return err
+	}
+
 	if err := os.WriteFile(clientcmd.NewDefaultPathOptions().GlobalFile, kubeConfig, 0644); err != nil {
 		return err
 	}

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,1 +1,1 @@
-- Fixed installation sequence of tools and Helm plugins.
+- Fixed Kubernetes context switch when the recommended home directory (~/.kube) does not exist.


### PR DESCRIPTION
…ry (~/.kube) does not exist