### PR TITLE
fix: handle `rmk cluster switch` for k3d clusters

### DIFF
--- a/cmd/cluster.go
+++ b/cmd/cluster.go
@@ -25,6 +25,8 @@ import (
 )
 
 const (
+	K3DClusterProvider = "k3d"
+
 	clusterIdentityNameSuffix   = "identity"
 	clusterIdentitySecretSuffix = "identity-secret"
 
@@ -410,6 +412,17 @@ func (cc *ClusterCommands) switchKubeContext() error {
 		if err != nil {
 			return err
 		}
+
+		if err := cc.mergeKubeConfigs(clusterContext); err != nil {
+			return err
+		}
+	case K3DClusterProvider:
+		clusterContext, err := cc.getK3DClusterContext()
+		if err != nil {
+			return err
+		}
+
+		cc.Conf.Name = fmt.Sprintf("%v-%v", util.K3DPrefix, cc.Conf.Name)
 
 		if err := cc.mergeKubeConfigs(clusterContext); err != nil {
 			return err

--- a/cmd/k3d.go
+++ b/cmd/k3d.go
@@ -192,3 +192,19 @@ func K3DAction(conf *config.Config, action func(k3dRunner K3DRunner) error) cli.
 		return action(newK3DCommands(conf, c, util.GetPwdPath("")))
 	}
 }
+
+func (cc *ClusterCommands) getK3DClusterContext() ([]byte, error) {
+	k := &K3DCommands{cc.ReleaseCommands}
+
+	if err := k.prepareK3D("kubeconfig", "get", cc.Conf.Name); err != nil {
+		return nil, err
+	}
+
+	k.SpecCMD.DisableStdOut = true
+
+	if err := releaseRunner(k).runCMD(); err != nil {
+		return nil, err
+	}
+
+	return k.SpecCMD.StdoutBuf.Bytes(), nil
+}


### PR DESCRIPTION
Currently, `rmk cluster switch` does not do anything when called on a K3D environment. This PR makes it switch the kube context as expected.